### PR TITLE
feat: Add support for the EXT-X-PROGRAM-DATE-TIME tag

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -40,4 +40,5 @@ Sanil Raut <sr1990003@gmail.com>
 Sergio Ammirata <sergio@ammirata.net>
 The Chromium Authors <*@chromium.org>
 Sveriges Television AB <*@svt.se>
+Setplex <*@setplex.com>
 

--- a/docs/source/options/hls_options.rst
+++ b/docs/source/options/hls_options.rst
@@ -98,3 +98,10 @@ HLS options
 
     Playback of Offline HLS assets shall use EXT-X-SESSION-KEY to declare all 
     eligible content keys in the master playlist.
+
+--hls_program_date_time_mode <mode>
+
+    ALL or FIRST. Adds EXT-X-PROGRAM-DATE-TIME tags to media playlists.
+    When set to ALL, the tag will be added after each segment.
+    When set to FIRST, it will be added before the first segment in the playlist
+    and before the first segment after EXT-X-DISCONTINUITY.

--- a/include/packager/hls_params.h
+++ b/include/packager/hls_params.h
@@ -21,6 +21,13 @@ enum class HlsPlaylistType {
   kLive,
 };
 
+/// Defines the modes for EXT-X-PROGRAM-DATE-TIME.
+enum class ProgramDateTimeMode {
+  kNone = 0,
+  kAll,
+  kFirst
+};
+
 /// HLS related parameters.
 struct HlsParams {
   /// HLS playlist type. See HLS specification for details.
@@ -72,6 +79,11 @@ struct HlsParams {
   std::optional<double> start_time_offset;
   /// Create EXT-X-SESSION-KEY in master playlist
   bool create_session_keys;
+  /// Adds EXT-X-PROGRAM-DATE-TIME tags to media playlists.
+  /// kAll - adds the tag before each segment.
+  /// kFirst - adds the tag before the first segment in the playlist
+  /// and before the first segment after EXT-X-DISCONTINUITY.
+  ProgramDateTimeMode program_date_time_mode = ProgramDateTimeMode::kNone;
 };
 
 }  // namespace shaka

--- a/packager/app/hls_flags.cc
+++ b/packager/app/hls_flags.cc
@@ -51,3 +51,10 @@ ABSL_FLAG(bool,
           false,
           "Playback of Offline HLS assets shall use EXT-X-SESSION-KEY "
           "to declare all eligible content keys in the master playlist.");
+ABSL_FLAG(std::string,
+          hls_program_date_time_mode,
+          "",
+          "ALL or FIRST. Adds EXT-X-PROGRAM-DATE-TIME tags to media playlists. "
+          "When set to ALL, the tag will be added before each segment. "
+          "When set to FIRST, it will be added before the first segment in the playlist "
+          "and before the first segment after EXT-X-DISCONTINUITY");

--- a/packager/app/hls_flags.h
+++ b/packager/app/hls_flags.h
@@ -17,5 +17,6 @@ ABSL_DECLARE_FLAG(std::string, hls_playlist_type);
 ABSL_DECLARE_FLAG(int32_t, hls_media_sequence_number);
 ABSL_DECLARE_FLAG(std::optional<double>, hls_start_time_offset);
 ABSL_DECLARE_FLAG(bool, create_session_keys);
+ABSL_DECLARE_FLAG(std::string, hls_program_date_time_mode);
 
 #endif  // PACKAGER_APP_HLS_FLAGS_H_

--- a/packager/app/packager_main.cc
+++ b/packager/app/packager_main.cc
@@ -186,6 +186,19 @@ bool GetHlsPlaylistType(const std::string& playlist_type,
   return true;
 }
 
+ProgramDateTimeMode GetProgramDateTimeMode(const std::string& mode) {
+  if (!mode.empty()) {
+    if (absl::AsciiStrToUpper(mode) == "ALL") {
+      return ProgramDateTimeMode::kAll;
+    } else if (absl::AsciiStrToUpper(mode) == "FIRST") {
+      return ProgramDateTimeMode::kFirst;
+    } else {
+      LOG(ERROR) << "Unrecognized program date time mode " << mode;
+    }
+  }
+  return ProgramDateTimeMode::kNone;
+}
+
 bool GetProtectionScheme(uint32_t* protection_scheme) {
   if (absl::GetFlag(FLAGS_protection_scheme) == "cenc") {
     *protection_scheme = EncryptionParams::kProtectionSchemeCenc;
@@ -544,6 +557,8 @@ std::optional<PackagingParams> GetPackagingParams() {
       absl::GetFlag(FLAGS_hls_media_sequence_number);
   hls_params.start_time_offset = absl::GetFlag(FLAGS_hls_start_time_offset);
   hls_params.create_session_keys = absl::GetFlag(FLAGS_create_session_keys);
+  hls_params.program_date_time_mode =
+      GetProgramDateTimeMode(absl::GetFlag(FLAGS_hls_program_date_time_mode));
 
   TestParams& test_params = packaging_params.test_params;
   test_params.dump_stream_info = absl::GetFlag(FLAGS_dump_stream_info);

--- a/packager/hls/base/media_playlist.cc
+++ b/packager/hls/base/media_playlist.cc
@@ -16,6 +16,7 @@
 #include <absl/log/log.h>
 #include <absl/strings/numbers.h>
 #include <absl/strings/str_format.h>
+#include <absl/time/time.h>
 
 #include <packager/file.h>
 #include <packager/hls/base/tag.h>
@@ -165,7 +166,6 @@ std::string CreatePlaylistHeader(
   return header;
 }
 
-
 }  // namespace
 
 HlsEntry::HlsEntry(HlsEntry::EntryType type) : type_(type) {}
@@ -181,6 +181,7 @@ class SegmentInfoEntry : public HlsEntry {
   // |duration_seconds| is duration in seconds.
   SegmentInfoEntry(const std::string& file_name,
                    int64_t start_time,
+                   absl::Time start_time_absolute,
                    double duration_seconds,
                    bool use_byte_range,
                    uint64_t start_byte_offset,
@@ -193,6 +194,7 @@ class SegmentInfoEntry : public HlsEntry {
   void set_duration_seconds(double duration_seconds) {
     duration_seconds_ = duration_seconds;
   }
+  void set_program_date_time(bool value) { program_date_time_ = value; }
 
  private:
   SegmentInfoEntry(const SegmentInfoEntry&) = delete;
@@ -200,7 +202,9 @@ class SegmentInfoEntry : public HlsEntry {
 
   const std::string file_name_;
   const int64_t start_time_;
+  const absl::Time start_time_absolute_;
   double duration_seconds_;
+  bool program_date_time_ = false;
   const bool use_byte_range_;
   const uint64_t start_byte_offset_;
   const uint64_t segment_file_size_;
@@ -209,6 +213,7 @@ class SegmentInfoEntry : public HlsEntry {
 
 SegmentInfoEntry::SegmentInfoEntry(const std::string& file_name,
                                    int64_t start_time,
+                                   absl::Time start_time_absolute,
                                    double duration_seconds,
                                    bool use_byte_range,
                                    uint64_t start_byte_offset,
@@ -217,6 +222,7 @@ SegmentInfoEntry::SegmentInfoEntry(const std::string& file_name,
     : HlsEntry(HlsEntry::EntryType::kExtInf),
       file_name_(file_name),
       start_time_(start_time),
+      start_time_absolute_(start_time_absolute),
       duration_seconds_(duration_seconds),
       use_byte_range_(use_byte_range),
       start_byte_offset_(start_byte_offset),
@@ -224,7 +230,17 @@ SegmentInfoEntry::SegmentInfoEntry(const std::string& file_name,
       previous_segment_end_offset_(previous_segment_end_offset) {}
 
 std::string SegmentInfoEntry::ToString() {
-  std::string result = absl::StrFormat("#EXTINF:%.3f,", duration_seconds_);
+  std::string result;
+
+  if (program_date_time_) {
+    absl::StrAppendFormat(
+        &result, "#EXT-X-PROGRAM-DATE-TIME:%s\n",
+        absl::FormatTime("%Y-%m-%dT%H:%M:%E3SZ", start_time_absolute_,
+                         absl::UTCTimeZone()));
+    program_date_time_ = false;
+  }
+
+  absl::StrAppendFormat(&result, "#EXTINF:%.3f,", duration_seconds_);
 
   if (use_byte_range_) {
     absl::StrAppendFormat(&result, "\n#EXT-X-BYTERANGE:%" PRIu64,
@@ -238,7 +254,6 @@ std::string SegmentInfoEntry::ToString() {
 
   return result;
 }
-
 
 class DiscontinuityEntry : public HlsEntry {
  public:
@@ -339,10 +354,10 @@ MediaPlaylist::MediaPlaylist(const HlsParams& hls_params,
       name_(name),
       group_id_(group_id),
       media_sequence_number_(hls_params_.media_sequence_number) {
-        // When there's a forced media_sequence_number, start with discontinuity
-        if (media_sequence_number_ > 0)
-          entries_.emplace_back(new DiscontinuityEntry());
-      }
+  // When there's a forced media_sequence_number, start with discontinuity
+  if (media_sequence_number_ > 0)
+    entries_.emplace_back(new DiscontinuityEntry());
+}
 
 MediaPlaylist::~MediaPlaylist() {}
 
@@ -497,8 +512,32 @@ bool MediaPlaylist::WriteToFile(const std::filesystem::path& file_path) {
       media_sequence_number_, discontinuity_sequence_number_,
       hls_params_.start_time_offset);
 
-  for (const auto& entry : entries_)
+  bool program_date_time =
+      hls_params_.program_date_time_mode != ProgramDateTimeMode::kNone;
+
+  for (const auto& entry : entries_) {
+    switch (entry->type()) {
+      case HlsEntry::EntryType::kExtInf:
+        if (program_date_time) {
+          reinterpret_cast<SegmentInfoEntry*>(entry.get())
+              ->set_program_date_time(true);
+
+          if (hls_params_.program_date_time_mode ==
+              ProgramDateTimeMode::kFirst) {
+            program_date_time = false;
+          }
+        }
+        break;
+      case HlsEntry::EntryType::kExtDiscontinuity:
+        program_date_time =
+            hls_params_.program_date_time_mode != ProgramDateTimeMode::kNone;
+        break;
+      default:
+        break;
+    }
+
     absl::StrAppendFormat(&content, "%s\n", entry->ToString().c_str());
+  }
 
   if (hls_params_.playlist_type == HlsPlaylistType::kVod) {
     content += "#EXT-X-ENDLIST\n";
@@ -534,6 +573,10 @@ void MediaPlaylist::SetTargetDuration(int32_t target_duration) {
   }
   target_duration_ = target_duration;
   target_duration_set_ = true;
+}
+
+void MediaPlaylist::SetReferenceTime(absl::Time reference_time) {
+  reference_time_ = reference_time;
 }
 
 int MediaPlaylist::GetNumChannels() const {
@@ -610,6 +653,10 @@ double MediaPlaylist::GetFrameRate() const {
          media_info_.video_info().frame_duration();
 }
 
+bool MediaPlaylist::IsDiscontinuity(int64_t start_time) const {
+  return start_time < last_start_time_;
+}
+
 void MediaPlaylist::AddSegmentInfoEntry(const std::string& segment_file_name,
                                         int64_t start_time,
                                         int64_t duration,
@@ -620,8 +667,8 @@ void MediaPlaylist::AddSegmentInfoEntry(const std::string& segment_file_name,
                  << " cannot be calculated. The output will be wrong.";
 
     entries_.emplace_back(new SegmentInfoEntry(
-        segment_file_name, 0.0, 0.0, use_byte_range_, start_byte_offset, size,
-        previous_segment_end_offset_));
+        segment_file_name, 0.0, absl::Time(), 0.0, use_byte_range_,
+        start_byte_offset, size, previous_segment_end_offset_));
     return;
   }
 
@@ -639,22 +686,25 @@ void MediaPlaylist::AddSegmentInfoEntry(const std::string& segment_file_name,
   bandwidth_estimator_.AddBlock(size, segment_duration_seconds);
   current_buffer_depth_ += segment_duration_seconds;
 
-  if (!entries_.empty() &&
-      entries_.back()->type() == HlsEntry::EntryType::kExtInf) {
-    const SegmentInfoEntry* segment_info =
-        static_cast<SegmentInfoEntry*>(entries_.back().get());
-    if (segment_info->start_time() > start_time) {
-      LOG(WARNING)
-          << "Insert a discontinuity tag after the segment with start time "
-          << segment_info->start_time() << " as the next segment starts at "
-          << start_time << ".";
-      entries_.emplace_back(new DiscontinuityEntry());
-    }
+  if (!entries_.empty() && IsDiscontinuity(start_time)) {
+    LOG(WARNING)
+        << "Insert a discontinuity tag after the segment with start time "
+        << last_start_time_ << " as the next segment starts at " << start_time
+        << ".";
+    entries_.emplace_back(new DiscontinuityEntry());
+  }
+  last_start_time_ = start_time;
+
+  absl::Time start_time_absolute;
+  if (reference_time_ != absl::Time()) {
+    start_time_absolute =
+        reference_time_ + absl::Seconds(start_time / time_scale_);
   }
 
   entries_.emplace_back(new SegmentInfoEntry(
-      segment_file_name, start_time, segment_duration_seconds, use_byte_range_,
-      start_byte_offset, size, previous_segment_end_offset_));
+      segment_file_name, start_time, start_time_absolute,
+      segment_duration_seconds, use_byte_range_, start_byte_offset, size,
+      previous_segment_end_offset_));
   previous_segment_end_offset_ = start_byte_offset + size - 1;
 }
 

--- a/packager/hls/base/media_playlist.h
+++ b/packager/hls/base/media_playlist.h
@@ -204,6 +204,14 @@ class MediaPlaylist {
   /// @param target_duration is the target duration for this playlist.
   virtual void SetTargetDuration(int32_t target_duration);
 
+  /// Sets a new value for the reference time,
+  /// allowing the calculation of absolute time based on the start time.
+  /// @param reference_time The new reference time to be set.
+  void SetReferenceTime(absl::Time reference_time);
+
+  /// @return Current value of the reference time.
+  absl::Time GetReferenceTime() { return reference_time_; };
+
   /// @return number of channels for audio. 0 is returned for video.
   virtual int GetNumChannels() const;
 
@@ -235,6 +243,11 @@ class MediaPlaylist {
   /// @return the language of the media, as an ISO language tag in its shortest
   ///         form.  May be an empty string for video.
   const std::string& language() const { return language_; }
+
+  /// @param start_time Start time of the segment to check if there was a
+  /// discontinuity between this segment and the last one added to the playlist.
+  /// @return Result of the discontinuity check.
+  bool IsDiscontinuity(int64_t start_time) const;
 
   const std::vector<std::string>& characteristics() const {
     return characteristics_;
@@ -301,6 +314,9 @@ class MediaPlaylist {
   bool target_duration_set_ = false;
   int32_t target_duration_ = 0;
 
+  // Reference time is the absolute time relative to the start time
+  absl::Time reference_time_;
+
   // TODO(kqyang): This could be managed better by a separate class, than having
   // all them managed in MediaPlaylist.
   std::list<std::unique_ptr<HlsEntry>> entries_;
@@ -308,6 +324,9 @@ class MediaPlaylist {
   // A list to hold the file names of the segments to be removed temporarily.
   // Once a file is actually removed, it is removed from the list.
   std::list<std::string> segments_to_be_removed_;
+
+  // Store the last start time to be able to detect discontinuities
+  int64_t last_start_time_ = 0;
 
   // Used by kVideoIFrameOnly playlists to track the i-frames (key frames).
   struct KeyFrameInfo {

--- a/packager/hls/base/media_playlist_unittest.cc
+++ b/packager/hls/base/media_playlist_unittest.cc
@@ -457,6 +457,95 @@ TEST_F(MediaPlaylistMultiSegmentTest, WriteToFileWithClearLead) {
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
+TEST_F(MediaPlaylistMultiSegmentTest, ProgramDateTime) {
+  // kMode, kExpectedOutput
+  const std::vector<std::pair<ProgramDateTimeMode, std::string>> test_data = {
+      {ProgramDateTimeMode::kAll,
+       "#EXTM3U\n"
+       "#EXT-X-VERSION:6\n"
+       "## Generated with https://github.com/shaka-project/shaka-packager "
+       "version test\n"
+       "#EXT-X-TARGETDURATION:10\n"
+       "#EXT-X-PLAYLIST-TYPE:VOD\n"
+       "#EXT-X-PROGRAM-DATE-TIME:2025-01-01T12:00:00.000Z\n"
+       "#EXTINF:10.000,\n"
+       "file.mp4\n"
+       "#EXT-X-PROGRAM-DATE-TIME:2025-01-01T12:00:10.000Z\n"
+       "#EXTINF:10.000,\n"
+       "file.mp4\n"
+       "#EXT-X-PROGRAM-DATE-TIME:2025-01-01T12:00:20.000Z\n"
+       "#EXTINF:10.000,\n"
+       "file.mp4\n"
+       "#EXT-X-DISCONTINUITY\n"
+       "#EXT-X-PROGRAM-DATE-TIME:2025-01-01T12:01:00.000Z\n"
+       "#EXTINF:10.000,\n"
+       "file.mp4\n"
+       "#EXT-X-PROGRAM-DATE-TIME:2025-01-01T12:01:10.000Z\n"
+       "#EXTINF:10.000,\n"
+       "file.mp4\n"
+       "#EXT-X-PROGRAM-DATE-TIME:2025-01-01T12:01:20.000Z\n"
+       "#EXTINF:10.000,\n"
+       "file.mp4\n"
+       "#EXT-X-ENDLIST\n"},
+      {ProgramDateTimeMode::kFirst,
+       "#EXTM3U\n"
+       "#EXT-X-VERSION:6\n"
+       "## Generated with https://github.com/shaka-project/shaka-packager "
+       "version test\n"
+       "#EXT-X-TARGETDURATION:10\n"
+       "#EXT-X-PLAYLIST-TYPE:VOD\n"
+       "#EXT-X-PROGRAM-DATE-TIME:2025-01-01T12:00:00.000Z\n"
+       "#EXTINF:10.000,\n"
+       "file.mp4\n"
+       "#EXTINF:10.000,\n"
+       "file.mp4\n"
+       "#EXTINF:10.000,\n"
+       "file.mp4\n"
+       "#EXT-X-DISCONTINUITY\n"
+       "#EXT-X-PROGRAM-DATE-TIME:2025-01-01T12:01:00.000Z\n"
+       "#EXTINF:10.000,\n"
+       "file.mp4\n"
+       "#EXTINF:10.000,\n"
+       "file.mp4\n"
+       "#EXTINF:10.000,\n"
+       "file.mp4\n"
+       "#EXT-X-ENDLIST\n"}};
+
+  for (const auto& [kMode, kExpectedOutput] : test_data) {
+    hls_params_.program_date_time_mode = kMode;
+    media_playlist_.reset(new MediaPlaylist(hls_params_, default_file_name_,
+                                            default_name_, default_group_id_));
+
+    valid_video_media_info_.set_reference_time_scale(kTimeScale);
+    ASSERT_TRUE(media_playlist_->SetMediaInfo(valid_video_media_info_));
+
+    absl::Time reference_time;
+    uint64_t duration = 10 * kTimeScale;
+
+    ASSERT_TRUE(absl::ParseTime(absl::RFC3339_full, "2025-01-01T06:00:00-06:00",
+                                &reference_time, nullptr));
+    media_playlist_->SetReferenceTime(reference_time);
+    for (int i = 0; i < 3; ++i) {
+      media_playlist_->AddSegment("file.mp4", duration * i, duration,
+                                  kZeroByteOffset, 1 * kMBytes);
+    }
+
+    // #EXT-X-DISCONTINUITY
+
+    ASSERT_TRUE(absl::ParseTime(absl::RFC3339_full, "2025-01-01T06:01:00-06:00",
+                                &reference_time, nullptr));
+    media_playlist_->SetReferenceTime(reference_time);
+    for (int i = 0; i < 3; ++i) {
+      media_playlist_->AddSegment("file.mp4", duration * i, duration,
+                                  kZeroByteOffset, 1 * kMBytes);
+    }
+
+    const char kMemoryFilePath[] = "memory://media.m3u8";
+    EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+    ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
+  }
+}
+
 TEST_F(MediaPlaylistMultiSegmentTest, GetLanguage) {
   MediaInfo media_info;
   media_info.set_reference_time_scale(kTimeScale);

--- a/packager/hls/base/simple_hls_notifier.cc
+++ b/packager/hls/base/simple_hls_notifier.cc
@@ -367,6 +367,28 @@ bool SimpleHlsNotifier::NotifyNewSegment(uint32_t stream_id,
   const std::string& segment_url =
       GenerateSegmentUrl(segment_name, hls_params().base_url,
                          master_playlist_dir_, media_playlist->file_name());
+
+  if (hls_params().program_date_time_mode != ProgramDateTimeMode::kNone) {
+    if (reference_time_ == absl::Time()) {
+      reference_time_ = absl::Now();
+      LOG(INFO) << "The reference time: " << reference_time_;
+    }
+    if (media_playlist->IsDiscontinuity(start_time)) {
+      // After a discontinuity, the new reference time should be set for all
+      // playlists to the first segment that passes the IsDiscontinuity check
+      if (absl::Now() - reference_time_ > absl::Seconds(duration)) {
+        reference_time_ = absl::Now();
+        LOG(INFO) << "The reference time has been changed "
+                     "due to a discontinuity: "
+                  << reference_time_;
+      }
+    }
+    if (media_playlist->GetReferenceTime() == absl::Time() ||
+        media_playlist->IsDiscontinuity(start_time)) {
+      media_playlist->SetReferenceTime(reference_time_);
+    }
+  }
+
   media_playlist->AddSegment(segment_url, start_time, duration,
                              start_byte_offset, size);
 

--- a/packager/hls/base/simple_hls_notifier.h
+++ b/packager/hls/base/simple_hls_notifier.h
@@ -94,6 +94,8 @@ class SimpleHlsNotifier : public HlsNotifier {
 
   absl::Mutex lock_;
 
+  absl::Time reference_time_;
+
   DISALLOW_COPY_AND_ASSIGN(SimpleHlsNotifier);
 };
 


### PR DESCRIPTION
* Add --hls_program_date_time_mode command line option with possible values 'all' and 'first'. 'all' - new tag is added before each segment. 'first' - new tag is added before the first segment in the playlist and before the first segment after the EXT-X-DISCONTINUITY tag

* Add IsDiscontinuity method to MediaPlaylist that takes the start_time of a segment not yet added to the playlist and returns whether there was a discontinuity between this segment and the last segment added to the playlist

* Add time reset after EXT-X-DISCONTINUITY for all media playlists

* Add unit tests