### PR TITLE
feat: Ability to change the initial value for #EXT-X-DISCONTINUITY-SEQUENCE tag

### DIFF
--- a/docs/source/options/hls_options.rst
+++ b/docs/source/options/hls_options.rst
@@ -76,6 +76,11 @@ HLS options
     The EXT-X-MEDIA-SEQUENCE documentation can be read here:
     https://tools.ietf.org/html/rfc8216#section-4.3.3.2.
 
+--hls_discontinuity_sequence_number <number>
+
+    Sets the initialization value for #EXT-X-DISCONTINUITY-SEQUENCE, 
+    required in case of a packager restart.
+
 --hls_start_time_offset <seconds>
 
     Sets EXT-X-START on the media playlists to specify the preferred point

--- a/include/packager/hls_params.h
+++ b/include/packager/hls_params.h
@@ -64,6 +64,9 @@ struct HlsParams {
   /// Custom EXT-X-MEDIA-SEQUENCE value to allow continuous media playback
   /// across packager restarts. See #691 for details.
   uint32_t media_sequence_number = 0;
+  /// Sets the initialization value for #EXT-X-DISCONTINUITY-SEQUENCE,
+  /// required in case of a packager restart
+  uint32_t discontinuity_sequence_number = 0;
   /// Sets EXT-X-START on the media playlists to specify the preferred point
   /// at wich the player should start playing.
   /// A positive number indicates a time offset from the beginning of the

--- a/packager/app/hls_flags.cc
+++ b/packager/app/hls_flags.cc
@@ -37,6 +37,11 @@ ABSL_FLAG(int32_t,
           "EXT-X-MEDIA-SEQUENCE value, which allows continuous media "
           "sequence across packager restarts. See #691 for more "
           "information about the reasoning of this and its use cases.");
+ABSL_FLAG(int32_t,
+          hls_discontinuity_sequence_number,
+          0,
+          "Number. Sets the initialization value for #EXT-X-DISCONTINUITY-SEQUENCE, "
+          "required in case of a packager restart");
 ABSL_FLAG(std::optional<double>,
           hls_start_time_offset,
           std::nullopt,

--- a/packager/app/hls_flags.h
+++ b/packager/app/hls_flags.h
@@ -15,6 +15,7 @@ ABSL_DECLARE_FLAG(std::string, hls_base_url);
 ABSL_DECLARE_FLAG(std::string, hls_key_uri);
 ABSL_DECLARE_FLAG(std::string, hls_playlist_type);
 ABSL_DECLARE_FLAG(int32_t, hls_media_sequence_number);
+ABSL_DECLARE_FLAG(int32_t, hls_discontinuity_sequence_number);
 ABSL_DECLARE_FLAG(std::optional<double>, hls_start_time_offset);
 ABSL_DECLARE_FLAG(bool, create_session_keys);
 

--- a/packager/app/packager_main.cc
+++ b/packager/app/packager_main.cc
@@ -542,6 +542,8 @@ std::optional<PackagingParams> GetPackagingParams() {
   hls_params.default_text_language = absl::GetFlag(FLAGS_default_text_language);
   hls_params.media_sequence_number =
       absl::GetFlag(FLAGS_hls_media_sequence_number);
+  hls_params.discontinuity_sequence_number =
+      absl::GetFlag(FLAGS_hls_discontinuity_sequence_number);
   hls_params.start_time_offset = absl::GetFlag(FLAGS_hls_start_time_offset);
   hls_params.create_session_keys = absl::GetFlag(FLAGS_create_session_keys);
 

--- a/packager/hls/base/media_playlist.cc
+++ b/packager/hls/base/media_playlist.cc
@@ -110,7 +110,7 @@ std::string CreatePlaylistHeader(
     HlsPlaylistType type,
     MediaPlaylist::MediaPlaylistStreamType stream_type,
     uint32_t media_sequence_number,
-    int discontinuity_sequence_number,
+    uint32_t discontinuity_sequence_number,
     std::optional<double> start_time_offset) {
   const std::string version = GetPackagerVersion();
   std::string version_line;
@@ -338,7 +338,9 @@ MediaPlaylist::MediaPlaylist(const HlsParams& hls_params,
       file_name_(file_name),
       name_(name),
       group_id_(group_id),
-      media_sequence_number_(hls_params_.media_sequence_number) {
+      media_sequence_number_(hls_params_.media_sequence_number),
+      discontinuity_sequence_number_(
+          hls_params_.discontinuity_sequence_number) {
         // When there's a forced media_sequence_number, start with discontinuity
         if (media_sequence_number_ > 0)
           entries_.emplace_back(new DiscontinuityEntry());

--- a/packager/hls/base/media_playlist.h
+++ b/packager/hls/base/media_playlist.h
@@ -285,8 +285,8 @@ class MediaPlaylist {
   std::vector<std::string> characteristics_;
   bool forced_subtitle_ = false;
   uint32_t media_sequence_number_ = 0;
+  uint32_t discontinuity_sequence_number_ = 0;
   bool inserted_discontinuity_tag_ = false;
-  int discontinuity_sequence_number_ = 0;
 
   double longest_segment_duration_seconds_ = 0.0;
   int32_t time_scale_ = 0;


### PR DESCRIPTION
* Add a command line parameter --hls_discontinuity_sequence_number that allows initializing the #EXT-X-DISCONTINUITY-SEQUENCE tag with a specified value. This is necessary for the stable operation of players in case of a packager restart